### PR TITLE
updates to improved Space.Struct fields api of space:base

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -1,7 +1,7 @@
 {
   "space:base": {
     "git": "https://github.com/meteor-space/base.git",
-    "version": "cbdadfe806badc4cfd86ce5e8c31fa188a7621b2"
+    "version": "9ffa935061ed85e9958a1810f77f57932a0cb60a"
   },
   "space:testing": {
     "git": "https://github.com/meteor-space/testing.git",

--- a/source/command.coffee
+++ b/source/command.coffee
@@ -8,10 +8,10 @@ class Space.messaging.Command extends Space.messaging.Serializable
     data.timestamp ?= new Date()
     super(data)
 
-  _getFields: ->
+  fields: ->
     fields = super()
     # Add default fields to all events
-    fields?.targetId ?= Match.OneOf(String, Guid)
-    fields?.version = Match.Optional(Match.Integer)
-    fields?.timestamp = Date
+    fields.targetId ?= Match.OneOf(String, Guid)
+    fields.version = Match.Optional(Match.Integer)
+    fields.timestamp = Date
     return fields

--- a/source/event.coffee
+++ b/source/event.coffee
@@ -1,5 +1,6 @@
 
 class Space.messaging.Event extends Space.messaging.Serializable
+
   @type 'Space.messaging.Event'
   eventVersion: 1
 
@@ -11,13 +12,13 @@ class Space.messaging.Event extends Space.messaging.Serializable
     data.timestamp ?= new Date()
     super(data)
 
-  _getFields: ->
+  fields: ->
     fields = super()
     # Add default fields to all events
-    fields?.sourceId ?= Match.Optional(Match.OneOf(String, Guid))
-    fields?.eventVersion = Match.Optional(Match.Integer)
-    fields?.version = Match.Optional(Match.Integer)
-    fields?.timestamp = Date
+    fields.sourceId ?= Match.Optional(Match.OneOf(String, Guid))
+    fields.eventVersion = Match.Optional(Match.Integer)
+    fields.version = Match.Optional(Match.Integer)
+    fields.timestamp = Date
     return fields
 
   _migrateToLatestVersion: (data) ->

--- a/source/serializable.coffee
+++ b/source/serializable.coffee
@@ -10,7 +10,7 @@ class Space.messaging.Serializable extends Space.Struct
     return this
 
   toJSONValue: ->
-    fields = @_getFields()
+    fields = @fields()
     # No special fields, simply parse instance to create deep copy
     if not fields?
       return JSON.parse JSON.stringify(this)
@@ -25,9 +25,8 @@ class Space.messaging.Serializable extends Space.Struct
 generateTypeNameMethod = (typeName) -> return -> typeName
 
 fromJSONValueFunction = (Class, json) ->
-  if Class.fields?
-    # Parse all fields that are set in the given json
-    for field of Class.fields when json[field]?
-      json[field] = EJSON.fromJSONValue(json[field])
+  # Parse all fields that are set in the given json
+  for field of Class::fields() when json[field]?
+    json[field] = EJSON.fromJSONValue(json[field])
 
   return new Class(json)

--- a/tests/unit/command_bus.unit.coffee
+++ b/tests/unit/command_bus.unit.coffee
@@ -9,7 +9,7 @@ describe 'Space.messaging.CommandBus', ->
   beforeEach ->
     @api = send: sinon.spy()
     @commandBus = new CommandBus { meteor: Meteor, api: @api }
-    @testCommand = new TestCommand()
+    @testCommand = new TestCommand targetId: new Guid()
     @handler = sinon.spy()
 
   it 'extends space object to be js compatible', ->


### PR DESCRIPTION
This PR updates to the more flexible `Space.Struct` fields api introduced in the latest space:base PR.
This change is backward-compatible and was necessary to fix a hard-to-detect bug in the event-sourcing package tests.