### PR TITLE
fixes static handler mixin bug discovered with publications

### DIFF
--- a/source/api.coffee
+++ b/source/api.coffee
@@ -26,8 +26,9 @@ class Space.messaging.Api extends Space.Object
     method[name] = body
     Meteor.methods method
 
-  @_setupMethod: (type) =>
+  @_setupMethod: (type) ->
     name = type.toString()
+    @_handlers ?= {}
     handlers = @_handlers
     return (param) ->
       try type = Space.resolvePath(name)

--- a/source/mixins/static-handlers.coffee
+++ b/source/mixins/static-handlers.coffee
@@ -7,13 +7,13 @@ Space.messaging.StaticHandlers = {
   statics: {
     _handlers: null
     _setupHandler: (name, handler) ->
+      @_ensureHandlersMap()
       @_handlers[name] = original: handler, bound: null
+    _ensureHandlersMap: -> @_handlers ?= {}
   }
 
-  onDependenciesReady: -> @_ensureHandlersMap()
-
   _getHandlerFor: (method) ->
-    @_ensureHandlersMap()
+    @constructor._ensureHandlersMap()
     @constructor._handlers[method]
 
   _bindHandlersToInstance: ->
@@ -21,7 +21,5 @@ Space.messaging.StaticHandlers = {
     for name, handler of handlers
       boundHandler = @underscore.bind handler.original, this
       handlers[name].bound = boundHandler
-
-  _ensureHandlersMap: -> @constructor._handlers ?= {}
 
 }

--- a/source/mixins/static-handlers.coffee
+++ b/source/mixins/static-handlers.coffee
@@ -10,8 +10,6 @@ Space.messaging.StaticHandlers = {
       @_handlers[name] = original: handler, bound: null
   }
 
-  onMixinApplied: -> @_handlers ?= {}
-
   _getHandlerFor: (method) ->
     @constructor._handlers ?= {}
     @constructor._handlers[method]

--- a/source/mixins/static-handlers.coffee
+++ b/source/mixins/static-handlers.coffee
@@ -10,8 +10,10 @@ Space.messaging.StaticHandlers = {
       @_handlers[name] = original: handler, bound: null
   }
 
+  onDependenciesReady: -> @_ensureHandlersMap()
+
   _getHandlerFor: (method) ->
-    @constructor._handlers ?= {}
+    @_ensureHandlersMap()
     @constructor._handlers[method]
 
   _bindHandlersToInstance: ->
@@ -19,5 +21,7 @@ Space.messaging.StaticHandlers = {
     for name, handler of handlers
       boundHandler = @underscore.bind handler.original, this
       handlers[name].bound = boundHandler
+
+  _ensureHandlersMap: -> @constructor._handlers ?= {}
 
 }

--- a/source/publication.coffee
+++ b/source/publication.coffee
@@ -23,6 +23,7 @@ class Space.messaging.Publication extends Space.Object
   @_registerPublication: (name, callback) -> Meteor.publish name, callback
 
   onDependenciesReady: ->
+    super
     @_setupDeclarativeMappings 'publications', @_setupDeclarativeHandler
     @_bindHandlersToInstance()
 

--- a/tests/integration/controller_command_handling.js
+++ b/tests/integration/controller_command_handling.js
@@ -27,6 +27,7 @@ describe("Handling commands", function() {
 
     // Integrate the controller in our test app
     let ControllerTestApp = Space.Application.define('ControllerTestApp', {
+      requiredModules: ['Space.messaging'],
       afterInitialize: function() {
         this.injector.map('MyController').toSingleton(MyController);
       }

--- a/tests/integration/controller_event_subscribing.js
+++ b/tests/integration/controller_event_subscribing.js
@@ -27,6 +27,7 @@ describe("Event subscribing", function() {
 
     // Integrate the controller in our test app
     let ControllerTestApp = Space.Application.define('ControllerTestApp', {
+      requiredModules: ['Space.messaging'],
       afterInitialize: function() {
         this.injector.map('MyController').toSingleton(MyController);
       }


### PR DESCRIPTION
The problem was the assignment of `@_handlers` in onMixinApplied hook which added the handlers to the `Space.messaging.Publication` class which resulted in shared handlers between subclasses