### PR TITLE
make space errors serializable when space:messaging is included

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -1,7 +1,7 @@
 {
   "space:base": {
     "git": "https://github.com/meteor-space/base.git",
-    "branch": "develop"
+    "branch": "feature/space-error-as-struct"
   },
   "space:testing": {
     "git": "https://github.com/meteor-space/testing.git",

--- a/git-packages.json
+++ b/git-packages.json
@@ -1,7 +1,7 @@
 {
   "space:base": {
     "git": "https://github.com/meteor-space/base.git",
-    "branch": "feature/space-error-as-struct"
+    "branch": "develop"
   },
   "space:testing": {
     "git": "https://github.com/meteor-space/testing.git",

--- a/package.js
+++ b/package.js
@@ -42,6 +42,7 @@ Package.onUse(function(api) {
     'source/value-objects/guid.coffee',
     'source/serializables/event.js',
     'source/serializables/command.js',
+    'source/serializables/error.js',
     'source/event_bus.coffee',
     'source/command_bus.coffee',
     'source/controller.coffee',
@@ -69,6 +70,7 @@ Package.onTest(function(api) {
   api.addFiles([
     'tests/unit/serializable.unit.coffee',
     'tests/unit/serializables/event.unit.coffee',
+    'tests/unit/serializables/space-error.tests.js',
     'tests/unit/event_bus.unit.coffee',
     'tests/unit/command_bus.unit.coffee',
     'tests/unit/api.unit.coffee',

--- a/source/serializables/error.js
+++ b/source/serializables/error.js
@@ -1,0 +1,3 @@
+// Make errors serializable
+Space.Error.mixin(Space.messaging.SerializableMixin);
+Space.Error.type('Space.Error');

--- a/tests/unit/serializables/space-error.tests.js
+++ b/tests/unit/serializables/space-error.tests.js
@@ -1,0 +1,23 @@
+describe("Space.messaging - Serializable Space.Error", function() {
+
+  let MyCustomValue = Space.Struct.extend({
+    mixin: [Space.messaging.SerializableMixin],
+    onExtending() { this.type('MyCustomValue'); },
+    statics: { fields: { value: String } }
+  });
+
+  let MyCustomError = Space.Error.extend('MyCustomError', {
+    onExtending() { this.type('MyCustomError'); },
+    statics: { fields: { custom: MyCustomValue } }
+  });
+
+  it("makes Space.Error serializable", function() {
+    let customValue = new MyCustomValue({ value: 'test' });
+    let error = new MyCustomError({ custom: customValue });
+    let copy = EJSON.parse(EJSON.stringify(error));
+    expect(copy).to.be.instanceof(MyCustomError);
+    expect(copy.custom).to.be.instanceof(MyCustomValue);
+    expect(copy.custom.value).to.equal(customValue.value);
+  });
+
+});


### PR DESCRIPTION
This PR makes `Space.Error` instances serializable by default, so they can be included in messages and transferred between client / server / mongoDB.