### PR TITLE
removes reset override in application helpers

### DIFF
--- a/source/mixins/application-helpers.coffee
+++ b/source/mixins/application-helpers.coffee
@@ -13,6 +13,4 @@ Space.Application.mixin {
 
   send: (command) -> @commandBus.send.apply(@commandBus, arguments)
 
-  # Tell all sub-modules to reset their data / stop long-living observers
-  reset: -> module.reset?() for _, module of @modules
 }


### PR DESCRIPTION
This PR fixes the issues with `Space.Application::reset` – this was an old artifact from the time before the improved module lifecycle :wink: 