### PR TITLE
Fixes 3 bugs in event-subscribing, add regression tests

### DIFF
--- a/.versions
+++ b/.versions
@@ -24,7 +24,7 @@ html-tools@1.0.5
 htmljs@1.0.5
 id-map@1.0.4
 jquery@1.11.4
-local-test:space:messaging@3.1.0
+local-test:space:messaging@3.1.1
 logging@1.0.8
 meteor@1.1.10
 minimongo@1.0.10
@@ -43,8 +43,8 @@ reactive-dict@1.1.3
 reactive-var@1.0.6
 retry@1.0.4
 routepolicy@1.0.6
-space:base@4.1.0
-space:messaging@3.1.0
+space:base@4.1.1
+space:messaging@3.1.1
 space:testing@3.0.1
 space:testing-messaging@3.0.1
 spacebars@1.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 Changelog
 =========
+## 3.1.1
+### Bug fixes
+- Regression bug with following methods:
+  - `Space.messaging.EventSubscribing.canHandleEvent`
+  - `Space.messaging.EventSubscribing._getEventHandlerFor`
+- Invalid logic in onConstruction callbacks in:
+  - `Space.messaging.EventSubscribing`
+  - `Space.messaging.CommandHandling`
+
 ## 3.1.0
 - Introduces [`Space.messaging.Versionable`](https://github.com/meteor-space/messaging/blob/master/source/mixins/versionable.js) mixin to allow any `Space.Struct` to be migrated to new versions as defined by `schemaVersion` using a transformation function such as `transformFromVersionX(data)`. This is particularly important once an `Ejsonable` `Space.Struct` is persisted.
   - Any changes to the struct’s fields require the version to be incremented by first adding the property  `schemaVersion`, which by default is set to 1, and then defining a transformation function.

--- a/git-packages.json
+++ b/git-packages.json
@@ -1,14 +1,1 @@
-{
-  "space:base": {
-    "git":"https://github.com/meteor-space/base.git",
-    "version": "e67cc6c69e8f8e1f505feae01dec7493b1f1187d"
-  },
-  "space:testing": {
-    "git":"https://github.com/meteor-space/testing.git",
-    "version": "53f24417c325500e1b836b88d5f03a17b2d97585"
-  },
-  "space:testing-messaging": {
-    "git":"https://github.com/meteor-space/testing-messaging.git",
-    "version": "644bd94b3e80007347cae1315293672f294cfc20"
-  }
-}
+{}

--- a/package.js
+++ b/package.js
@@ -16,7 +16,7 @@ Package.onUse(function(api) {
     'ejson',
     'ecmascript',
     'fongandrew:find-and-modify@0.2.1',
-    'space:base@4.1.0'
+    'space:base@4.1.1'
   ]);
 
   // SHARED
@@ -64,7 +64,7 @@ Package.onTest(function(api) {
     'mongo',
     'ecmascript',
     'space:testing@3.0.1',
-    'space:testing-messaging@3.0.0',
+    'space:testing-messaging@3.0.1',
     'space:messaging',
     'practicalmeteor:munit@2.1.5'
   ]);

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary: 'Messaging infrastructure for Space applications.',
   name: 'space:messaging',
-  version: '3.1.0',
+  version: '3.1.1',
   git: 'https://github.com/meteor-space/messaging.git'
 });
 

--- a/source/mixins/command-handling.js
+++ b/source/mixins/command-handling.js
@@ -31,6 +31,10 @@ Space.messaging.CommandHandling = {
     this._setupCommandHandling();
   },
 
+  canHandleCommand(command) {
+    return this._getCommandHandlerFor(command) !== undefined;
+  },
+
   register(commandType, handler) {
     if (!commandType) {
       throw new Error(this.ERRORS.invalidCommandType(commandType));
@@ -47,10 +51,6 @@ Space.messaging.CommandHandling = {
       throw new Error(this.ERRORS.noCommandHandlerFound(command.typeName()));
     }
     handler.call(this, command);
-  },
-
-  canHandleCommand(command) {
-    return this._getCommandHandlerFor(command) !== undefined;
   },
 
   _setupCommandHandling() {

--- a/source/mixins/command-handling.js
+++ b/source/mixins/command-handling.js
@@ -19,8 +19,12 @@ Space.messaging.CommandHandling = {
     }
   },
 
+  _commandHandlers: null,
+
   onConstruction() {
-    this._commandHandlers = this._commandHandlers || {};
+    if (this._commandHandlers === null) {
+      this._commandHandlers = {};
+    }
   },
 
   onDependenciesReady() {

--- a/source/mixins/event-subscribing.js
+++ b/source/mixins/event-subscribing.js
@@ -5,18 +5,14 @@ Space.messaging.EventSubscribing = {
     meteor: 'Meteor'
   },
 
-  _eventHandlers: null,
-
-  onConstruction() {
-    this._eventHandlers = this._eventHandlers || {};
-  },
+  _eventHandlers: {},
 
   onDependenciesReady() {
     this._setupEventSubscribing();
   },
 
   canHandleEvent(event) {
-    this._getEventHandlerFor(event) !== undefined;
+    return this._getEventHandlerFor(event) !== undefined;
   },
 
   subscribe(eventType, handler) {
@@ -58,7 +54,7 @@ Space.messaging.EventSubscribing = {
   },
 
   _getEventHandlerFor(event) {
-    this._eventHandlers[event.typeName()];
+    return this._eventHandlers[event.typeName()];
   },
 
   _onException(error) { throw error; }

--- a/source/mixins/event-subscribing.js
+++ b/source/mixins/event-subscribing.js
@@ -8,7 +8,6 @@ Space.messaging.EventSubscribing = {
   _eventHandlers: null,
 
   onConstruction() {
-    console.log('in')
     if (this._eventHandlers === null) {
       this._eventHandlers = {};
     }

--- a/source/mixins/event-subscribing.js
+++ b/source/mixins/event-subscribing.js
@@ -5,7 +5,14 @@ Space.messaging.EventSubscribing = {
     meteor: 'Meteor'
   },
 
-  _eventHandlers: {},
+  _eventHandlers: null,
+
+  onConstruction() {
+    console.log('in')
+    if (this._eventHandlers === null) {
+      this._eventHandlers = {};
+    }
+  },
 
   onDependenciesReady() {
     this._setupEventSubscribing();

--- a/tests/unit/mixins/command-handling.tests.js
+++ b/tests/unit/mixins/command-handling.tests.js
@@ -1,8 +1,8 @@
-const CommandHandling = Space.messaging.CommandHandling;
 
 describe("Space.messaging.CommandHandling", function() {
 
-  let MyClass = Space.Object.extend({ mixin: CommandHandling });
+  const CommandHandling = Space.messaging.CommandHandling;
+  const MyClass = Space.Object.extend({ mixin: CommandHandling });
 
   it("does not provide empty default", function() {
     expect(MyClass.prototype.commandHandlers).not.to.exist;

--- a/tests/unit/mixins/command-handling.tests.js
+++ b/tests/unit/mixins/command-handling.tests.js
@@ -1,8 +1,13 @@
 
 describe("Space.messaging.CommandHandling", function() {
 
-  const CommandHandling = Space.messaging.CommandHandling;
-  const MyClass = Space.Object.extend({ mixin: CommandHandling });
+  const MyClass = Space.Object.extend({
+    mixin: Space.messaging.CommandHandling
+  });
+  const MyCommand = Space.messaging.Command.extend(
+    'Space.messaging.CommandHandling.__Test__.MyCommand',
+    {}
+  );
 
   it("does not provide empty default", function() {
     expect(MyClass.prototype.commandHandlers).not.to.exist;
@@ -13,6 +18,62 @@ describe("Space.messaging.CommandHandling", function() {
       new MyClass({ underscore: _ }).onDependenciesReady();
     };
     expect(createWithoutHandlers).not.to.throw(Error);
+  });
+
+  describe("public methods", function() {
+
+    beforeEach(function () {
+      this.myClassInstance = new MyClass({
+        meteor: Meteor,
+        commandBus: new Space.messaging.CommandBus,
+        underscore: _
+      });
+      this.myCommandInstance = new MyCommand();
+    });
+
+    describe("canHandleCommand", function () {
+
+      it("returns true if object has a registered handler function", function () {
+        const handler = sinon.spy();
+        this.myClassInstance.register(MyCommand, handler);
+        expect(this.myClassInstance.canHandleCommand(this.myCommandInstance)).to.be.true;
+      });
+
+      it("returns false if object has no registered handler functions", function () {
+        const handler = sinon.spy();
+        expect(this.myClassInstance.canHandleCommand(this.myCommandInstance)).to.be.false;
+      });
+
+    });
+
+    describe("register", function () {
+
+      it("registers the provided function to handle the specified command sent through the command bus", function () {
+        const handler = sinon.spy();
+        this.myClassInstance.register(MyCommand, handler);
+        expect(this.myClassInstance.commandBus.hasHandlerFor(this.myCommandInstance)).to.be.true;
+      });
+
+    });
+
+    describe("handle", function () {
+
+      it("calls the handler when passed a command it can handle", function () {
+        const handler = sinon.spy();
+        this.myClassInstance.register(MyCommand, handler);
+        this.myClassInstance.handle(this.myCommandInstance);
+        expect(handler).to.have.been.called;
+      });
+
+      it("throws an error if the command cannot be handled", function () {
+        const createWithoutHandlers = function () {
+          this.myClassInstance.handle(this.myCommandInstance);
+        };
+        expect(createWithoutHandlers).to.throw.error;
+      });
+
+    });
+
   });
 
 });

--- a/tests/unit/mixins/event-subscribing.tests.js
+++ b/tests/unit/mixins/event-subscribing.tests.js
@@ -1,9 +1,8 @@
 
 describe("Space.messaging.EventSubscribing", function() {
 
-  const EventBus = new Space.messaging.EventBus;
   const EventSubscribing = Space.messaging.EventSubscribing;
-
+  const EventBus = new Space.messaging.EventBus;
   const MyClass = Space.Object.extend({ mixin: EventSubscribing });
   const MyEvent = Space.messaging.Event.extend(
     'Space.messaging.EventSubscribing.__Test__.MyEvent',

--- a/tests/unit/mixins/event-subscribing.tests.js
+++ b/tests/unit/mixins/event-subscribing.tests.js
@@ -1,9 +1,9 @@
 
 describe("Space.messaging.EventSubscribing", function() {
 
-  const EventSubscribing = Space.messaging.EventSubscribing;
-  const EventBus = new Space.messaging.EventBus;
-  const MyClass = Space.Object.extend({ mixin: EventSubscribing });
+  const MyClass = Space.Object.extend({
+    mixin: Space.messaging.EventSubscribing
+  });
   const MyEvent = Space.messaging.Event.extend(
     'Space.messaging.EventSubscribing.__Test__.MyEvent',
     {}
@@ -25,7 +25,7 @@ describe("Space.messaging.EventSubscribing", function() {
     beforeEach(function() {
       this.myClassInstance = new MyClass({
         meteor: Meteor,
-        eventBus: EventBus,
+        eventBus: new Space.messaging.EventBus,
         underscore: _
       });
       this.myEventInstance = new MyEvent();

--- a/tests/unit/mixins/event-subscribing.tests.js
+++ b/tests/unit/mixins/event-subscribing.tests.js
@@ -3,12 +3,8 @@ describe("Space.messaging.EventSubscribing", function() {
 
   const EventBus = new Space.messaging.EventBus;
   const EventSubscribing = Space.messaging.EventSubscribing;
-  EventSubscribing.meteor = Meteor;
-  EventSubscribing.eventBus = EventBus;
-  EventSubscribing.underscore = _;
 
   const MyClass = Space.Object.extend({ mixin: EventSubscribing });
-
   const MyEvent = Space.messaging.Event.extend(
     'Space.messaging.EventSubscribing.__Test__.MyEvent',
     {}
@@ -20,9 +16,14 @@ describe("Space.messaging.EventSubscribing", function() {
 
   it("can handle events when handler functions are subscribed for the type", function() {
     const handler = sinon.spy();
-    MyClass.prototype.subscribe(MyEvent, handler);
+    const myClassInstance = new MyClass({
+      meteor: Meteor,
+      eventBus: EventBus,
+      underscore: _
+    });
+    myClassInstance.subscribe(MyEvent, handler);
     const myEventInstance = new MyEvent();
-    expect(MyClass.prototype.canHandleEvent(myEventInstance)).to.be.true;
+    expect(myClassInstance.canHandleEvent(myEventInstance)).to.be.true;
   });
 
   it("does not throw error if no handlers have been defined", function() {

--- a/tests/unit/mixins/event-subscribing.tests.js
+++ b/tests/unit/mixins/event-subscribing.tests.js
@@ -10,24 +10,35 @@ describe("Space.messaging.EventSubscribing", function() {
     {}
   );
 
-  beforeEach(function() {
-    this.myClassInstance = new MyClass({
-      meteor: Meteor,
-      eventBus: EventBus,
-      underscore: _
-    });
-    this.myEventInstance = new MyEvent();
-  });
-
   it("does not provide empty default", function() {
     expect(MyClass.prototype.eventSubscriptions).not.to.exist;
   });
 
-  it("can handle events when handler functions are subscribed for the type", function() {
-    const handler = sinon.spy();
-    this.myClassInstance.subscribe(MyEvent, handler);
-    expect(this.myClassInstance.canHandleEvent(this.myEventInstance)).to.be.true;
+  describe("handling events", function(){
+
+    beforeEach(function() {
+      this.myClassInstance = new MyClass({
+        meteor: Meteor,
+        eventBus: EventBus,
+        underscore: _
+      });
+      this.myEventInstance = new MyEvent();
+    });
+
+    it("can handle events when handler functions are subscribed for the type", function() {
+      const handler = sinon.spy();
+      this.myClassInstance.subscribe(MyEvent, handler);
+      expect(this.myClassInstance.canHandleEvent(this.myEventInstance)).to.be.true;
+    });
+
+    it("calls the handler when passed an event it can handle", function() {
+      const handler = sinon.spy();
+      this.myClassInstance.subscribe(MyEvent, handler);
+      this.myClassInstance.on(this.myEventInstance);
+      expect(handler).to.have.been.called;
+    });
   });
+
 
   it("does not throw error if no handlers have been defined", function() {
     const createWithoutHandlers = function() {

--- a/tests/unit/mixins/event-subscribing.tests.js
+++ b/tests/unit/mixins/event-subscribing.tests.js
@@ -37,6 +37,14 @@ describe("Space.messaging.EventSubscribing", function() {
       this.myClassInstance.on(this.myEventInstance);
       expect(handler).to.have.been.called;
     });
+
+    it("throws an error if the event cannot be handled", function() {
+      const createWithoutHandlers = function() {
+        this.myClassInstance.on(this.myEventInstance);
+      };
+      expect(createWithoutHandlers).to.throw.error;
+    });
+
   });
 
 

--- a/tests/unit/mixins/event-subscribing.tests.js
+++ b/tests/unit/mixins/event-subscribing.tests.js
@@ -1,11 +1,28 @@
-const EventSubscribing = Space.messaging.EventSubscribing;
 
 describe("Space.messaging.EventSubscribing", function() {
 
-  let MyClass = Space.Object.extend({ mixin: EventSubscribing });
+  const EventBus = new Space.messaging.EventBus;
+  const EventSubscribing = Space.messaging.EventSubscribing;
+  EventSubscribing.meteor = Meteor;
+  EventSubscribing.eventBus = EventBus;
+  EventSubscribing.underscore = _;
+
+  const MyClass = Space.Object.extend({ mixin: EventSubscribing });
+
+  const MyEvent = Space.messaging.Event.extend(
+    'Space.messaging.EventSubscribing.__Test__.MyEvent',
+    {}
+  );
 
   it("does not provide empty default", function() {
     expect(MyClass.prototype.eventSubscriptions).not.to.exist;
+  });
+
+  it("can handle events when handler functions are subscribed for the type", function() {
+    const handler = sinon.spy();
+    MyClass.prototype.subscribe(MyEvent, handler);
+    const myEventInstance = new MyEvent();
+    expect(MyClass.prototype.canHandleEvent(myEventInstance)).to.be.true;
   });
 
   it("does not throw error if no handlers have been defined", function() {

--- a/tests/unit/mixins/event-subscribing.tests.js
+++ b/tests/unit/mixins/event-subscribing.tests.js
@@ -14,7 +14,14 @@ describe("Space.messaging.EventSubscribing", function() {
     expect(MyClass.prototype.eventSubscriptions).not.to.exist;
   });
 
-  describe("handling events", function(){
+  it("does not throw error if no handlers have been defined", function() {
+    const createWithoutHandlers = function() {
+      new MyClass({ underscore: _ }).onDependenciesReady();
+    };
+    expect(createWithoutHandlers).not.to.throw(Error);
+  });
+
+  describe("public methods", function() {
 
     beforeEach(function() {
       this.myClassInstance = new MyClass({
@@ -25,34 +32,49 @@ describe("Space.messaging.EventSubscribing", function() {
       this.myEventInstance = new MyEvent();
     });
 
-    it("can handle events when handler functions are subscribed for the type", function() {
-      const handler = sinon.spy();
-      this.myClassInstance.subscribe(MyEvent, handler);
-      expect(this.myClassInstance.canHandleEvent(this.myEventInstance)).to.be.true;
+    describe("canHandleEvent", function() {
+
+      it("returns true if object has a subscribed handler function", function () {
+        const handler = sinon.spy();
+        this.myClassInstance.subscribe(MyEvent, handler);
+        expect(this.myClassInstance.canHandleEvent(this.myEventInstance)).to.be.true;
+      });
+
+      it("returns false if object has no subscribed handler functions", function () {
+        const handler = sinon.spy();
+        expect(this.myClassInstance.canHandleEvent(this.myEventInstance)).to.be.false;
+      });
+
     });
 
-    it("calls the handler when passed an event it can handle", function() {
-      const handler = sinon.spy();
-      this.myClassInstance.subscribe(MyEvent, handler);
-      this.myClassInstance.on(this.myEventInstance);
-      expect(handler).to.have.been.called;
+    describe("subscribe", function() {
+
+      it("subscribes the provided function to handle the specified event sent through the event bus", function () {
+        const handler = sinon.spy();
+        this.myClassInstance.subscribe(MyEvent, handler);
+        expect(this.myClassInstance.eventBus.hasHandlerFor(this.myEventInstance)).to.be.true;
+      });
+
     });
 
-    it("throws an error if the event cannot be handled", function() {
-      const createWithoutHandlers = function() {
+    describe("on", function(){
+
+      it("calls the handler when passed an event it can handle", function() {
+        const handler = sinon.spy();
+        this.myClassInstance.subscribe(MyEvent, handler);
         this.myClassInstance.on(this.myEventInstance);
-      };
-      expect(createWithoutHandlers).to.throw.error;
+        expect(handler).to.have.been.called;
+      });
+
+      it("throws an error if the event cannot be handled", function() {
+        const createWithoutHandlers = function() {
+          this.myClassInstance.on(this.myEventInstance);
+        };
+        expect(createWithoutHandlers).to.throw.error;
+      });
+
     });
 
-  });
-
-
-  it("does not throw error if no handlers have been defined", function() {
-    const createWithoutHandlers = function() {
-      new MyClass({ underscore: _ }).onDependenciesReady();
-    };
-    expect(createWithoutHandlers).not.to.throw(Error);
   });
 
 });

--- a/tests/unit/mixins/event-subscribing.tests.js
+++ b/tests/unit/mixins/event-subscribing.tests.js
@@ -10,20 +10,23 @@ describe("Space.messaging.EventSubscribing", function() {
     {}
   );
 
+  beforeEach(function() {
+    this.myClassInstance = new MyClass({
+      meteor: Meteor,
+      eventBus: EventBus,
+      underscore: _
+    });
+    this.myEventInstance = new MyEvent();
+  });
+
   it("does not provide empty default", function() {
     expect(MyClass.prototype.eventSubscriptions).not.to.exist;
   });
 
   it("can handle events when handler functions are subscribed for the type", function() {
     const handler = sinon.spy();
-    const myClassInstance = new MyClass({
-      meteor: Meteor,
-      eventBus: EventBus,
-      underscore: _
-    });
-    myClassInstance.subscribe(MyEvent, handler);
-    const myEventInstance = new MyEvent();
-    expect(myClassInstance.canHandleEvent(myEventInstance)).to.be.true;
+    this.myClassInstance.subscribe(MyEvent, handler);
+    expect(this.myClassInstance.canHandleEvent(this.myEventInstance)).to.be.true;
   });
 
   it("does not throw error if no handlers have been defined", function() {


### PR DESCRIPTION
- construct with an empty object, as onConstruction hook had flawed and
unessesary logic
- missing return statements on canHandleEvent and  _getEventHandlerFor
due to CS migration
- Also adds regression tests