### PR TITLE
Add helper to commandBus to return the types of commands it can handle

### DIFF
--- a/source/command_bus.coffee
+++ b/source/command_bus.coffee
@@ -37,6 +37,8 @@ class Space.messaging.CommandBus extends Space.Object
 
   getHandlerFor: (commandType) -> @_handlers[commandType]
 
+  getHandledCommandTypes: -> commandType for commandType of @_handlers
+
   hasHandlerFor: (commandType) -> @getHandlerFor(commandType)?
 
   onSend: (handler) -> @_onSendCallbacks.push handler

--- a/tests/unit/command_bus.unit.coffee
+++ b/tests/unit/command_bus.unit.coffee
@@ -24,6 +24,13 @@ describe 'Space.messaging.CommandBus', ->
       registerTwice = => @commandBus.registerHandler TestCommand, second
       expect(registerTwice).to.throw Error
 
+    it 'can provide the types of commands it can handle', ->
+      handler = ->
+      @commandBus.registerHandler TestCommand, handler
+      expect(@commandBus.getHandledCommandTypes()).to.deep.equal(
+        ['Space.messaging.CommandBusStubCommand']
+      )
+
     it 'allows handler registrations to be overridden', ->
       first = sinon.spy()
       second = sinon.spy()

--- a/tests/unit/event_bus.unit.coffee
+++ b/tests/unit/event_bus.unit.coffee
@@ -26,6 +26,13 @@ describe 'Space.messaging.EventBus', ->
       expect(first).to.have.been.calledWith @testEvent
       expect(second).to.have.been.calledWith @testEvent
 
+    it 'can provide the types of events it can handle', ->
+      subscriber = ->
+      @eventBus.subscribeTo TestEvent, subscriber
+      expect(@eventBus.getHandledEventTypes()).to.deep.equal(
+        ['Space.messaging.__tests__.EventBusStubEvent']
+      )
+
   describe 'publishing events', ->
 
     it 'calls the subscription with the event', ->


### PR DESCRIPTION
This is needed for an upcoming PR in ES relating to scoping the commitProcessing query to just the messages the app can handle