### PR TITLE
Fix/pass through send callback on server too

### DIFF
--- a/package.js
+++ b/package.js
@@ -15,7 +15,6 @@ Package.onUse(function(api) {
     'check',
     'ejson',
     'ecmascript',
-    'fongandrew:find-and-modify@0.2.2',
     'space:base@4.1.3'
   ]);
 

--- a/source/command_bus.coffee
+++ b/source/command_bus.coffee
@@ -22,10 +22,10 @@ class Space.messaging.CommandBus extends Space.Object
       if !handler?
         message = "Missing command handler for <#{command.typeName()}>."
         throw new Error message
-      handler(command)
+      handler(command, callback)
     else
       # ON THE CLIENT
-      @api.send command, callback
+      @api.send(command, callback)
 
   registerHandler: (typeName, handler, overrideExisting) ->
     if @_handlers[typeName]? and !overrideExisting

--- a/source/command_bus.coffee
+++ b/source/command_bus.coffee
@@ -18,7 +18,7 @@ class Space.messaging.CommandBus extends Space.Object
     if @meteor.isServer
       # ON THE SERVER
       handler = @_handlers[command.typeName()]
-      callback(command) for callback in @_onSendCallbacks
+      cb(command) for cb in @_onSendCallbacks
       if !handler?
         message = "Missing command handler for <#{command.typeName()}>."
         throw new Error message

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export PACKAGE_DIRS='packages'
+export METEOR_PACKAGE_DIRS='packages'
 
 if [ "$PORT" ]; then
   meteor test-packages ./ --port $PORT

--- a/tests/integration/controller_command_handling.js
+++ b/tests/integration/controller_command_handling.js
@@ -33,13 +33,14 @@ describe("Handling commands", function() {
     // Startup app and send the commands through the bus
     let app = new ControllerTestApp();
     let myController = app.injector.get('MyController');
+    let myCallback = () => {};
     app.start();
     app.commandBus.send(this.myCommand);
-    app.commandBus.send(this.anotherCommand);
+    app.commandBus.send(this.anotherCommand, myCallback);
 
     // Expect that the controller handled the commands
-    expect(myHandler).to.have.been.calledWithExactly(this.myCommand).calledOn(myController);
-    expect(anotherHandler).to.have.been.calledWithExactly(this.anotherCommand).calledOn(myController);
+    expect(myHandler).to.have.been.calledWith(this.myCommand).calledOn(myController);
+    expect(anotherHandler).to.have.been.calledWithExactly(this.anotherCommand, myCallback).calledOn(myController);
 
   });
 });

--- a/tests/unit/command_bus.unit.coffee
+++ b/tests/unit/command_bus.unit.coffee
@@ -43,7 +43,17 @@ describe 'Space.messaging.CommandBus', ->
     it.server 'calls the registered handler with the command', ->
       @commandBus.registerHandler TestCommand, @handler
       @commandBus.send @testCommand
-      expect(@handler).to.have.been.calledWithExactly @testCommand
+      expect(@handler).to.have.been.calledWith @testCommand
+
+    it.server 'calls the registered handler with an optional callback', ->
+      @commandBus.registerHandler TestCommand, @handler
+      callback = ->
+      @commandBus.send @testCommand, callback
+      expect(@handler).to.have.been.calledWithExactly @testCommand, callback
+
+    it.client 'uses api.send for sending commands with optional callback', ->
+      @commandBus.send @testCommand
+      expect(@api.send).to.have.been.calledWith @testCommand
 
     it.client 'uses api.send for sending commands', ->
       callback = ->

--- a/tests/unit/helpers.tests.js
+++ b/tests/unit/helpers.tests.js
@@ -1,36 +1,41 @@
-describe("Space.messaging.define", function() {
+describe("Space.messaging.define", () => {
 
-  const myNamespace = Space.namespace('My.define.Namespace');
+  describe("batch defining serializable objects", () => {
 
-  Space.messaging.define(Space.messaging.Event, myNamespace, {
-    FirstEvent: {},
-    SecondEvent: {}
-  });
-
-  Space.messaging.define(Space.messaging.Event, 'My.define.Namespace', {
-    ThirdEvent: {}
-  });
-
-  it("creates namespaced serializables", function() {
-    expect(myNamespace.FirstEvent).to.extend(Space.messaging.Event);
-    expect(myNamespace.SecondEvent).to.extend(Space.messaging.Event);
-    expect(myNamespace.ThirdEvent).to.extend(Space.messaging.Event);
-  });
-
-});
-
-describe("Space.messaging.define", function() {
-
-  beforeEach(function() {
-    this.definedSerializables = Space.messaging.define(Space.messaging.Event, {
-      FirstEvent: {},
-      SecondEvent: {}
+    it("returns object with defined serializables", () => {
+      const definedSerializables = Space.messaging.define(Space.messaging.Event, {
+        FirstEvent: {},
+        SecondEvent: {}
+      });
+      expect(definedSerializables.FirstEvent).to.extend(Space.messaging.Event);
+      expect(definedSerializables.SecondEvent).to.extend(Space.messaging.Event);
     });
+
   });
 
-  it("returns object with defined serializables", function() {
-    expect(this.definedSerializables.FirstEvent).to.extend(Space.messaging.Event);
-    expect(this.definedSerializables.SecondEvent).to.extend(Space.messaging.Event);
-  });
+  describe("use with a Space.namespace", () => {
+
+    beforeEach(() => {
+      this.myNamespace = Space.namespace('My.define.Namespace');
+    });
+
+    it("creates namespaced serializables when passing a Space.namespace object as the second argument", () => {
+      Space.messaging.define(Space.messaging.Event, this.myNamespace, {
+        FirstEvent: {},
+        SecondEvent: {}
+      });
+      expect(this.myNamespace.FirstEvent).to.extend(Space.messaging.Event);
+      expect(this.myNamespace.SecondEvent).to.extend(Space.messaging.Event);
+    });
+
+    it("creates namespaced serializables when passing the string reference of a Space.namespace as the second argument", () => {
+      Space.messaging.define(Space.messaging.Event, 'My.define.Namespace', {
+        ThirdEvent: {}
+      });
+      expect(this.myNamespace.ThirdEvent).to.extend(Space.messaging.Event);
+    });
+  })
 
 });
+
+

--- a/tests/unit/helpers.tests.js
+++ b/tests/unit/helpers.tests.js
@@ -1,8 +1,8 @@
-describe("Space.messaging.define", () => {
+describe("Space.messaging.define", function() {
 
-  describe("batch defining serializable objects", () => {
+  describe("batch defining serializable objects", function() {
 
-    it("returns object with defined serializables", () => {
+    it("returns object with defined serializables", function() {
       const definedSerializables = Space.messaging.define(Space.messaging.Event, {
         FirstEvent: {},
         SecondEvent: {}
@@ -13,13 +13,13 @@ describe("Space.messaging.define", () => {
 
   });
 
-  describe("use with a Space.namespace", () => {
+  describe("use with a Space.namespace", function() {
 
-    beforeEach(() => {
+    beforeEach(function() {
       this.myNamespace = Space.namespace('My.define.Namespace');
     });
 
-    it("creates namespaced serializables when passing a Space.namespace object as the second argument", () => {
+    it("creates namespaced serializables when passing a Space.namespace object as the second argument", function() {
       Space.messaging.define(Space.messaging.Event, this.myNamespace, {
         FirstEvent: {},
         SecondEvent: {}
@@ -28,7 +28,7 @@ describe("Space.messaging.define", () => {
       expect(this.myNamespace.SecondEvent).to.extend(Space.messaging.Event);
     });
 
-    it("creates namespaced serializables when passing the string reference of a Space.namespace as the second argument", () => {
+    it("creates namespaced serializables when passing the string reference of a Space.namespace as the second argument", function() {
       Space.messaging.define(Space.messaging.Event, 'My.define.Namespace', {
         ThirdEvent: {}
       });


### PR DESCRIPTION
Prerequisite for meteor-space/event-sourcing#95
Callback is now passed to the server command handler
